### PR TITLE
feat: experimentalCursorStream mode to fix backpressure

### DIFF
--- a/scripts/oom.script.ts
+++ b/scripts/oom.script.ts
@@ -1,0 +1,85 @@
+/*
+
+yarn tsn oom
+
+ */
+
+import { Transform, Writable } from 'stream'
+import { DBQuery } from '@naturalcycles/db-lib'
+import { _pipeline, requireEnvKeys, transformLogProgress } from '@naturalcycles/nodejs-lib'
+import { runScript } from '@naturalcycles/nodejs-lib/dist/script'
+import { DatastoreDB } from '../src'
+
+const { SECRET_GCP_SERVICE_ACCOUNT } = requireEnvKeys('SECRET_GCP_SERVICE_ACCOUNT')
+process.env['APP_ENV'] = 'master'
+
+const db = new DatastoreDB({
+  credentials: JSON.parse(SECRET_GCP_SERVICE_ACCOUNT),
+  useLegacyGRPC: true,
+})
+
+// const TABLE = 'TEST1'
+const TABLE = 'UserFertilityCache'
+
+runScript(async () => {
+  // prepare
+  // const items = _range(0, 10_000).map(i => ({
+  //   id: `id_${i}`,
+  //   data: Buffer.alloc(1_000_000).fill(1),
+  // }))
+  //
+  // console.log('items ok')
+  //
+  // await _pipeline([
+  //   Readable.from(items),
+  //   transformMap(async item => {
+  //     await db.saveBatch(TABLE, [item], {
+  //       excludeFromIndexes: ['data'],
+  //     })
+  //   }, {
+  //     concurrency: 16,
+  //     predicate: _passthroughPredicate,
+  //   }),
+  //   transformLogProgress({logEvery: 10}),
+  //   writableVoid(),
+  // ])
+
+  await _pipeline([
+    db.streamQuery(DBQuery.create(TABLE), {
+      experimentalCursorStream: true,
+      batchSize: 1000,
+      rssLimitMB: 1000,
+      debug: true,
+    }),
+
+    // This thing logs every 100's object + some memory and speed metrics
+    transformLogProgress({
+      metric: 'read',
+      logEvery: 1000,
+      peakRSS: true,
+    }),
+
+    // This is a fake Consumer that introduces a 100ms delay before passing the data further
+    new Transform({
+      objectMode: true,
+      transform(chunk: any, _encoding, cb) {
+        setTimeout(() => cb(null, chunk), 5)
+      },
+    }),
+
+    transformLogProgress({
+      metric: 'processed',
+      logEvery: 1000,
+      peakRSS: true,
+    }),
+
+    // This is a "no-op" consumer that just discards the data
+    new Writable({
+      objectMode: true,
+      write(c, _encoding, cb) {
+        // console.log(c.id, c.data.length)
+        cb()
+      },
+    }),
+  ])
+})

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,11 @@
+//
+// tsconfig.json for /scripts
+//
+{
+  "extends": "@naturalcycles/dev-lib/scripts/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "../dist"
+  },
+  "exclude": ["**/__exclude"]
+}

--- a/src/DatastoreStreamReadable.ts
+++ b/src/DatastoreStreamReadable.ts
@@ -1,0 +1,111 @@
+import { Readable } from 'stream'
+import { Query } from '@google-cloud/datastore'
+import { _ms } from '@naturalcycles/js-lib'
+import { ReadableTyped } from '@naturalcycles/nodejs-lib'
+
+export class DatastoreStreamReadable<T = any> extends Readable implements ReadableTyped<T> {
+  private originalLimit: number
+  private rowsRetrieved = 0
+  private endCursor?: string
+  private running = false
+  private done = false
+  private lastQueryDone?: number
+  private totalWait = 0
+
+  // private log = (...args: any[]): void => console.log(...args)
+  private log = console.log.bind(console)
+
+  constructor(private q: Query, private batchSize = 100, private rssLimitMB = 1000, debug = false) {
+    super({ objectMode: true })
+
+    if (!debug) this.log = () => {}
+
+    this.originalLimit = q.limitVal
+
+    console.log(`!! using experimentalCursorStream !! batchSize: ${batchSize}`)
+  }
+
+  private async runNextQuery(): Promise<void> {
+    if (this.done) return
+
+    if (this.lastQueryDone) {
+      const now = Date.now()
+      this.totalWait += now - this.lastQueryDone
+    }
+
+    this.running = true
+    // console.log('running query...')
+
+    let limit = this.batchSize
+
+    if (this.originalLimit) {
+      limit = Math.min(this.batchSize, this.originalLimit - this.rowsRetrieved)
+    }
+
+    // console.log(`limit: ${limit}`)
+    let q = this.q.limit(limit)
+    if (this.endCursor) {
+      q = q.start(this.endCursor)
+    }
+
+    try {
+      const [rows, info] = await q.run()
+
+      this.rowsRetrieved += rows.length
+      this.log(
+        `got ${rows.length} rows, ${this.rowsRetrieved} rowsRetrieved, totalWait: ${_ms(
+          this.totalWait,
+        )}`,
+        info.moreResults,
+      )
+
+      this.endCursor = info.endCursor
+      this.running = false // ready to take more _reads
+      this.lastQueryDone = Date.now()
+
+      rows.forEach(row => this.push(row))
+
+      if (
+        !info.endCursor ||
+        info.moreResults === 'NO_MORE_RESULTS' ||
+        (this.originalLimit && this.rowsRetrieved >= this.originalLimit)
+      ) {
+        this.log(
+          `!!!! DONE! ${this.rowsRetrieved} rowsRetrieved, totalWait: ${_ms(this.totalWait)}`,
+        )
+        this.push(null)
+        this.done = true
+      } else if (this.rssLimitMB) {
+        const rssMB = Math.round(process.memoryUsage().rss / 1024 / 1024)
+
+        if (rssMB <= this.rssLimitMB) {
+          void this.runNextQuery()
+        } else {
+          this.log(`rssLimitMB reached ${rssMB} > ${this.rssLimitMB}, pausing stream`)
+        }
+      }
+    } catch (err) {
+      console.error('DatastoreStreamReadable error!\n', err)
+      this.emit('error', err)
+    }
+  }
+
+  count = 0 // use for debugging
+
+  override _read(): void {
+    // console.log(`_read called ${++this.count}, wasRunning: ${this.running}`) // debugging
+    this.count++
+    if (this.running) {
+      console.warn(`_read ${this.count}, wasRunning: true`)
+    }
+
+    if (this.done) {
+      console.warn(`!!! _read was called, but done==true`)
+      return
+    }
+
+    if (!this.running) {
+      void this.runNextQuery()
+    }
+  }
+}

--- a/src/datastore.model.ts
+++ b/src/datastore.model.ts
@@ -42,6 +42,40 @@ export interface DatastoreCredentials {
   refresh_token?: string
 }
 
+export interface DatastoreDBStreamOptions extends DatastoreDBOptions {
+  /**
+   * Set to `true` to stream via experimental "cursor-query based stream".
+   *
+   * @default false
+   */
+  experimentalCursorStream?: boolean
+
+  /**
+   * Applicable to `experimentalCursorStream`
+   *
+   * @default 100
+   */
+  batchSize?: number
+
+  /**
+   * Applicable to `experimentalCursorStream`
+   *
+   * Set to a value (number of Megabytes) to control the peak RSS size.
+   * If limit is reached - streaming will pause until the stream keeps up, and then
+   * resumes.
+   *
+   * @default 1000
+   */
+  rssLimitMB?: number
+
+  /**
+   * Set to `true` to log additional debug info, when using experimentalCursorStream.
+   *
+   * @default false
+   */
+  debug?: boolean
+}
+
 export interface DatastoreDBOptions extends CommonDBOptions {
   tx?: Transaction
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import { DatastoreDB } from './datastore.db'
 import {
   DatastoreCredentials,
   DatastoreDBCfg,
+  DatastoreDBOptions,
+  DatastoreDBSaveOptions,
+  DatastoreDBStreamOptions,
   DatastorePayload,
   DatastorePropertyStats,
   DatastoreStats,
@@ -17,6 +20,9 @@ export type {
   DatastoreStats,
   DatastoreCredentials,
   DatastorePropertyStats,
+  DatastoreDBStreamOptions,
+  DatastoreDBOptions,
+  DatastoreDBSaveOptions,
 }
 
 export { DatastoreDB, DatastoreType, getDBAdapter, DatastoreKeyValueDB }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
-  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.14.5", "@babel/code-frame@^7.15.8":
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.15.8.tgz#45990c47adadb00c03677baa89221f7cc23d2503"
+  integrity sha512-2IAnmn8zbvC/jKYhq5Ki9I+DwjlrtMPUCH/CpHvqI4dNnlwHwsxoIhlc8WcYY5LSYknXQtAlFYuHfqAFCvQ4Wg==
   dependencies:
     "@babel/highlight" "^7.14.5"
 
@@ -22,19 +22,19 @@
   integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
 
 "@babel/core@>=7.9.0", "@babel/core@^7.1.0", "@babel/core@^7.12.16", "@babel/core@^7.7.2", "@babel/core@^7.7.5":
-  version "7.15.5"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
-  integrity sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.8.tgz#195b9f2bffe995d2c6c159e72fe525b4114e8c10"
+  integrity sha512-3UG9dsxvYBMYwRv+gS41WKHno4K60/9GPy1CJaH6xy3Elq8CTtvtjT5R5jmNhXfCYLX2mTw+7/aq5ak/gOE0og==
   dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.15.4"
+    "@babel/code-frame" "^7.15.8"
+    "@babel/generator" "^7.15.8"
     "@babel/helper-compilation-targets" "^7.15.4"
-    "@babel/helper-module-transforms" "^7.15.4"
+    "@babel/helper-module-transforms" "^7.15.8"
     "@babel/helpers" "^7.15.4"
-    "@babel/parser" "^7.15.5"
+    "@babel/parser" "^7.15.8"
     "@babel/template" "^7.15.4"
     "@babel/traverse" "^7.15.4"
-    "@babel/types" "^7.15.4"
+    "@babel/types" "^7.15.6"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -43,20 +43,20 @@
     source-map "^0.5.0"
 
 "@babel/eslint-parser@^7.12.16":
-  version "7.15.7"
-  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.7.tgz#2dc3d0ff0ea22bb1e08d93b4eeb1149bf1c75f2d"
-  integrity sha512-yJkHyomClm6A2Xzb8pdAo4HzYMSXFn1O5zrCYvbFP0yQFvHueLedV8WiEno8yJOKStjUXzBZzJFeWQ7b3YMsqQ==
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.15.8.tgz#8988660b59d739500b67d0585fd4daca218d9f11"
+  integrity sha512-fYP7QFngCvgxjUuw8O057SVH5jCXsbFFOoE77CFDcvzwBVgTOkMD/L4mIC5Ud1xf8chK/no2fRbSSn1wvNmKuQ==
   dependencies:
     eslint-scope "^5.1.1"
     eslint-visitor-keys "^2.1.0"
     semver "^6.3.0"
 
-"@babel/generator@^7.15.4", "@babel/generator@^7.7.2":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.4.tgz#85acb159a267ca6324f9793986991ee2022a05b0"
-  integrity sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
+"@babel/generator@^7.15.4", "@babel/generator@^7.15.8", "@babel/generator@^7.7.2":
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.8.tgz#fa56be6b596952ceb231048cf84ee499a19c0cd1"
+  integrity sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==
   dependencies:
-    "@babel/types" "^7.15.4"
+    "@babel/types" "^7.15.6"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -107,10 +107,10 @@
   dependencies:
     "@babel/types" "^7.15.4"
 
-"@babel/helper-module-transforms@^7.15.4":
-  version "7.15.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz#7da80c8cbc1f02655d83f8b79d25866afe50d226"
-  integrity sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==
+"@babel/helper-module-transforms@^7.15.8":
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz#d8c0e75a87a52e374a8f25f855174786a09498b2"
+  integrity sha512-DfAfA6PfpG8t4S6npwzLvTUpp0sS7JrcuaMiy1Y5645laRJIp/LiLGIBbQKaXSInK8tiGNI7FL7L8UvB8gdUZg==
   dependencies:
     "@babel/helper-module-imports" "^7.15.4"
     "@babel/helper-replace-supers" "^7.15.4"
@@ -185,10 +185,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
-  version "7.15.7"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.7.tgz#0c3ed4a2eb07b165dfa85b3cc45c727334c4edae"
-  integrity sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==
+"@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.8", "@babel/parser@^7.7.2":
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.8.tgz#7bacdcbe71bdc3ff936d510c15dcea7cf0b99016"
+  integrity sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -778,9 +778,9 @@
     typescript "^4.0.2"
 
 "@naturalcycles/db-lib@^8.0.0":
-  version "8.16.1"
-  resolved "https://registry.yarnpkg.com/@naturalcycles/db-lib/-/db-lib-8.16.1.tgz#e5db83215ba12824fc7bcd8ca9a2a540bcab943f"
-  integrity sha512-8J9G9A6npOWm+xlm/atQx+VhWHxWcdcvJGyDlhkD1bU+NBdZHzFfS01UFQFx30JC8xbBdmUwOpijA9KKu/jD8A==
+  version "8.16.2"
+  resolved "https://registry.yarnpkg.com/@naturalcycles/db-lib/-/db-lib-8.16.2.tgz#7bacf6f06041c4dcfc1a3cfe1660f9cda3130ef6"
+  integrity sha512-7F3T0XmljicuLTbKfme89BbKyR6lGnuiXOq3ow6yCn1iS1Mr04HHqXaklnPGe6xndJ6Ypiz237JfrVSKaz0XxQ==
   dependencies:
     "@naturalcycles/js-lib" "^14.0.0"
     "@naturalcycles/nodejs-lib" "^12.0.0"
@@ -836,9 +836,9 @@
     tslib "^2.0.0"
 
 "@naturalcycles/nodejs-lib@^12.0.0", "@naturalcycles/nodejs-lib@^12.8.0":
-  version "12.37.0"
-  resolved "https://registry.yarnpkg.com/@naturalcycles/nodejs-lib/-/nodejs-lib-12.37.0.tgz#07732ae05244039ed5b0acee9e73745e16b836fa"
-  integrity sha512-8ZWo2D/f0CzkxfoSwbODg9RNnduvqJxCc15uOJy91sCZ5UlnHaxnD9Xo0FbNeKnhXYAQ/pPWxDtSd1ZS6CKPYw==
+  version "12.38.0"
+  resolved "https://registry.yarnpkg.com/@naturalcycles/nodejs-lib/-/nodejs-lib-12.38.0.tgz#9ac4fa26577fd9d6128a12b21105a81a959f5da2"
+  integrity sha512-MmhVllezNcOBppPkTnxKYdp3120wO51GpzMoKO/F36Fbx+N1eeT2QMciXNVIgQDcuEPKrLFU8l6NyUi9z0g1vw==
   dependencies:
     "@naturalcycles/js-lib" "^14.0.0"
     "@naturalcycles/time-lib" "^3.0.1"
@@ -1165,9 +1165,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0", "@types/node@^16.0.0":
-  version "16.10.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.2.tgz#5764ca9aa94470adb4e1185fe2e9f19458992b2e"
-  integrity sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==
+  version "16.10.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
+  integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -1508,15 +1508,15 @@ array-ify@^1.0.0:
   integrity sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=
 
 array-includes@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
-  integrity sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.4.tgz#f5b493162c760f3539631f005ba2bb46acb45ba9"
+  integrity sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.2"
+    es-abstract "^1.19.1"
     get-intrinsic "^1.1.1"
-    is-string "^1.0.5"
+    is-string "^1.0.7"
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -1561,15 +1561,15 @@ asynckit@^0.4.0:
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 autoprefixer@^9.8.6:
-  version "9.8.7"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.7.tgz#e3c12de18a800af1a1a8155fbc01dc7de29ea184"
-  integrity sha512-7Hg99B1eTH5+LgmUBUSmov1Z3bsggQJS7v3IMGo6wcScnbRuvtMc871J9J+4bSbIqa9LSX/zypFXJ8sXHpMJeQ==
+  version "9.8.8"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.8.tgz#fd4bd4595385fa6f06599de749a4d5f7a474957a"
+  integrity sha512-eM9d/swFopRt5gdJ7jrpCwgvEMIayITpojhkkSMRsFHYuH5bkSQ4p/9qTEHtmNudUZh22Tehu7I6CxAW0IXTKA==
   dependencies:
     browserslist "^4.12.0"
     caniuse-lite "^1.0.30001109"
-    nanocolors "^0.2.8"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
+    picocolors "^0.2.1"
     postcss "^7.0.32"
     postcss-value-parser "^4.1.0"
 
@@ -1789,9 +1789,9 @@ camelcase@^6.2.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001264:
-  version "1.0.30001264"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001264.tgz#88f625a60efb6724c7c62ac698bc8dbd9757e55b"
-  integrity sha512-Ftfqqfcs/ePiUmyaySsQ4PUsdcYyXG2rfoBVsk3iY1ahHaJEw65vfb7Suzqm+cEkwwPIv/XWkg27iCpRavH4zA==
+  version "1.0.30001265"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz#0613c9e6c922e422792e6fcefdf9a3afeee4f8c3"
+  integrity sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -2321,9 +2321,9 @@ ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
     safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.3.857:
-  version "1.3.857"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.857.tgz#dcc239ff8a12b6e4b501e6a5ad20fd0d5a3210f9"
-  integrity sha512-a5kIr2lajm4bJ5E4D3fp8Y/BRB0Dx2VOcCRE5Gtb679mXIME/OFhWler8Gy2ksrf8gFX+EFCSIGA33FB3gqYpg==
+  version "1.3.861"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.861.tgz#981e37a79af7a7b29bbaeed36376f4795527de13"
+  integrity sha512-GZyflmpMnZRdZ1e2yAyvuFwz1MPSVQelwHX4TJZyXypB8NcxdPvPNwy5lOTxnlkrK13EiQzyTPugRSnj6cBgKg==
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -2366,7 +2366,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.18.0-next.2, es-abstract@^1.19.0, es-abstract@^1.19.1:
+es-abstract@^1.19.0, es-abstract@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
   integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
@@ -2523,9 +2523,9 @@ eslint-plugin-unused-imports@^1.1.1:
     eslint-rule-composer "^0.3.0"
 
 eslint-plugin-vue@^7.18.0:
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-7.18.0.tgz#02a452142330c7f27c242db21a1b9e25238540f6"
-  integrity sha512-ceDXlXYMMPMSXw7tdKUR42w9jlzthJGJ3Kvm3YrZ0zuQfvAySNxe8sm6VHuksBW0+060GzYXhHJG6IHVOfF83Q==
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-7.19.1.tgz#435fb2ce712842a9530b28eacb883680e8eaa4f3"
+  integrity sha512-e2pD7nW2sTY04ThH+66BgToNwC4n6dqfNhKE+ypdJFtZgn3Zn+nP8ZEIFPG0PGqCKQ3qxy8dJk1bzUsuQd3ANA==
   dependencies:
     eslint-utils "^2.1.0"
     natural-compare "^1.4.0"
@@ -3626,9 +3626,9 @@ istanbul-lib-source-maps@^4.0.0:
     source-map "^0.6.1"
 
 istanbul-reports@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.2.tgz#d593210e5000683750cb09fc0644e4b6e27fd53b"
-  integrity sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.0.3.tgz#974d682037f6d12b15dc55f9a2a5f8f1ea923831"
+  integrity sha512-0i77ZFLsb9U3DHi22WzmIngVzfoyxxbQcZRqlF3KoKmCJGq9nhFHoGi8FqBztN2rE8w6hURnZghetn0xpkVb6A==
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
@@ -4659,15 +4659,10 @@ nan@^2.13.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
   integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
 
-nanocolors@^0.2.8:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/nanocolors/-/nanocolors-0.2.12.tgz#4d05932e70116078673ea4cc6699a1c56cc77777"
-  integrity sha512-SFNdALvzW+rVlzqexid6epYdt8H9Zol7xDoQarioEFcFN0JHo4CYNztAxmtfgGTVRCmFlEOqqhBpoFGKqSAMug==
-
 nanoid@^3.0.0:
-  version "3.1.28"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.28.tgz#3c01bac14cb6c5680569014cc65a2f26424c6bd4"
-  integrity sha512-gSu9VZ2HtmoKYe/lmyPFES5nknFrHa+/DT9muUFWFMi6Jh9E1I7bkvlQ8xxf1Kos9pi9o8lBnIOkatMhKX/YUw==
+  version "3.1.29"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.29.tgz#214fb2d7a33e1a5bef4757b779dfaeb6a4e5aeb4"
+  integrity sha512-dW2pUSGZ8ZnCFIlBIA31SV8huOGCHb6OwzVCc7A69rb/a+SgPBwfmLvK5TKQ3INPbRkcI8a/Owo0XbiTNH19wg==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Works around this issue: https://github.com/googleapis/nodejs-datastore/issues/859
by implementing a custom Readable that respects backpressure.
To not get too slow, allows to set `rssLimitMB`.
Until `rssLimitMB` is reached - it works like the official library ("downloads whole internet"),
but gently pauses as soons as `rssLimitMB` is reached.