### PR TITLE
fix: fix rolling back expired transaction

### DIFF
--- a/src/datastore.db.ts
+++ b/src/datastore.db.ts
@@ -374,7 +374,7 @@ export class DatastoreDB extends BaseCommonDB implements CommonDB {
       await fn(tx)
       await datastoreTx.commit()
     } catch (err) {
-      await datastoreTx.rollback()
+      await this.rollback(datastoreTx)
       throw err
     }
   }
@@ -547,6 +547,19 @@ export class DatastoreDB extends BaseCommonDB implements CommonDB {
       errorData: {
         fingerprint: [DATASTORE_TIMEOUT],
       },
+    }
+  }
+
+  /**
+   * Silently rollback the transaction.
+   * It may happen that transaction is already committed/rolled back, so we don't want to throw an error here.
+   */
+  private async rollback(datastoreTx: Transaction): Promise<void> {
+    try {
+      await datastoreTx.rollback()
+    } catch (err) {
+      // log the error, but don't re-throw, as this should be a graceful rollback
+      this.cfg.logger.error(err)
     }
   }
 }


### PR DESCRIPTION
In this PR, I am fixing an issue where in some cases we were trying to rollback an already rolled back transaction.

This happens when inside a transaction callback, the business logic throws an error.
In this case the `CommonDao.runInTransaction` catches the error first, and it rolls the transaction back and then forward-throws the error.
After that, the DB-connector , usually the `Datastore.runInTransaction` catches the forward-thrown error, and so tries to roll back the transaction.
But in this case, the rollback is not silenced -> it is called directly on the Datastore's own Transaction object which throws.

This PR intends to fix this case.

---

### Log from a real life example:

In the main application we run a transaction and throw an AppError from inside.

```
accountPatchHandler
accountPatchHandler - Entering the transaction
  CommonDao.runInTransaction
    DatastoreDB.runInTransaction
      CommonDao.runInTransaction - catch
        AppError: The old password is not correct
        CommonDao.runInTransaction - rolling back
          DatastoreDBTransaction.rollback
            DatastoreDBTransaction.rollback - rolling back
            DatastoreDBTransaction.rollback - rolled back
        CommonDao.runInTransaction - rolled back
      DatastoreDB.runInTransaction - catch
        AppError: The old password is not correct
        DatastoreDB.runInTransaction - rolling back
          DatastoreDB.runInTransaction - catch - datastoreTx.rollback error
            Error: This transaction has already expired.

genericErrorHandler
Error: This transaction has already expired.

respondWithError
Error: This transaction has already expired.
```

What happens is CommonDao sees the error first, and rollsback and forward-throws the error:

```
// CommonDao
    await this.cfg.db.runInTransaction(async tx => {
      const daoTx = new CommonDaoTransaction(tx, this.cfg.logger!)

      try {
        r = await fn(daoTx)
      } catch (err) {
        await daoTx.rollback() // graceful rollback that "never throws"
        throw err
      }
    }, opt)
```

and the forward-thrown error reaches `this.cfg.db.runInTransaction` which looks like this:

```
// Datastore-Lib
    try {
      await datastoreTx.run()
      const tx = new DatastoreDBTransaction(this, datastoreTx)
      await fn(tx)
      await datastoreTx.commit()
    } catch (err) {
      await datastoreTx.rollback()
      throw err
    }
  }
```

so the forward-thrown error reaches its catch block too, and tries to call rollback again.

At this point, we call the pure Datastore Transaction.rollback, which throws the "Expired Transaction" error. (So, this is not our wrapper anymore, but a pure datastore function.)